### PR TITLE
add prod deploy CI & rework workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ on:
         required: false
         default: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -51,6 +55,9 @@ jobs:
   build:
     uses: ./.github/workflows/docker.yml
     needs: [test]
+    permissions:
+      contents: read
+      id-token: write
     with:
       environment: ${{ inputs.environment }}
       image: ${{ inputs.image }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,10 @@ on:
         description: "Version to build"
         required: true
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   deploy:
     name: Deploy Marble NER API

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ on:
         description: "Whether to push the container image or not"
         default: false
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build_container_image:
     name: Build container image

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,27 @@
+name: Deploy to staging
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      environment: production
+      image: europe-west1-docker.pkg.dev/marble-infra/marble/marble-ner:${{ github.ref_name }}
+      push: true
+
+  deploy:
+    needs: [build]
+    uses: ./.github/workflows/deploy.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      environment: production
+      image: europe-west1-docker.pkg.dev/marble-infra/marble/marble-ner:${{ github.ref_name }}


### PR DESCRIPTION
Fixes https://github.com/checkmarble/marble-ner/security/code-scanning/4, https://github.com/checkmarble/marble-ner/security/code-scanning/1, https://github.com/checkmarble/marble-ner/security/code-scanning/2, https://github.com/checkmarble/marble-ner/security/code-scanning/1
And will allow to deploy prod by pushing a v*.*.* tag (like on the other repos).
I did the repository configuration to allow this.